### PR TITLE
checking tinymce.getDoc() in $watch(attrs.ngModel, ...)

### DIFF
--- a/tx-tinymce.js
+++ b/tx-tinymce.js
@@ -82,7 +82,7 @@ angular.module('tx-tinymce',[])
       //Watch scope for changes in model and update
       //tinymce when needed.
       scope.$watch(attrs.ngModel,function(value,old){
-        if (tinymce && angular.isDefined(value)) {
+        if (tinymce && angular.isDefined(value) && tinymce.getDoc()) {
           var content = tinymce.getContent();
           if (angular.isString(value) && content !== value) {
             tinymce.setContent(value);


### PR DESCRIPTION
This patch remedies an error I was receiving:

```
TypeError: Cannot read property 'body' of undefined
    at Object.S.getBody (tinymce.min.js:10)
    at Object.S.getContent (tinymce.min.js:10)
    at Object.fn (tx-tinymce.js:86)
    at Scope.parent.$get.Scope.$digest (angular.js:14397)
    at Scope.parent.$get.Scope.$apply (angular.js:14660)
    at done (angular.js:9734)
    at completeRequest (angular.js:9924)
    at XMLHttpRequest.requestLoaded (angular.js:9865)
```
